### PR TITLE
Add Entra ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,20 @@ docker service create \
 
 ## 🎭 Joke API
 
-### Налаштування зовнішнього API
+### Jokes API
 
-```bash
-# В config.env або як змінна середовища
-JOKES_API_URL=http://joke-api:8080
-JOKES_API_KEY=your_api_key_here  # опціонально
-JOKES_API_TIMEOUT=15             # опціонально
-```
+*   `JOKES_API_URL` - The base URL of the jokes API.
+*   `JOKES_API_KEY` - (Optional) The API key for the jokes API.
+*   `JOKES_API_TIMEOUT` - (Optional) The timeout for the jokes API in seconds. Default: `5`.
+*   `JOKES_API_ENDPOINT` - (Optional) The endpoint for the jokes API. Default: `/api/getJoke`.
+
+### Entra ID for Jokes API
+
+*   `USE_ENTRA_ID_FOR_JOKES_API` - Set to `true` to use Entra ID for authentication with the Jokes API. Default: `false`.
+*   `ENTRA_ID_TENANT_ID` - The tenant ID for your Azure application.
+*   `ENTRA_ID_CLIENT_ID` - The client ID for your Azure application.
+*   `ENTRA_ID_CLIENT_SECRET` - The client secret for your Azure application.
+*   `ENTRA_ID_SCOPE` - The scope for the API you are calling (e.g., `api://your-api-client-id/.default`).
 
 ### Підтримувані формати API
 

--- a/config.py
+++ b/config.py
@@ -2,8 +2,10 @@
 Configuration module for Telegram Bot
 """
 import os
+import logging
 from typing import List, Dict, Any
 from dotenv import load_dotenv
+import msal
 
 from base import BaseConfig
 from constants import BotConstants, APIConstants
@@ -14,39 +16,68 @@ if os.path.exists('config.env'):
 
 class Config(BaseConfig):
     """Bot configuration class"""
-    
+
     # Bot credentials from environment variable
     BOT_TOKEN = os.getenv('BOT_TOKEN')
-    
+
     # Bot information
     BOT_NAME = os.getenv('BOT_NAME', BotConstants.DEFAULT_BOT_NAME)
     BOT_VERSION = os.getenv('BOT_VERSION', BotConstants.DEFAULT_BOT_VERSION)
     BOT_DEVELOPER = os.getenv('BOT_DEVELOPER', BotConstants.DEFAULT_BOT_DEVELOPER)
     BOT_EMAIL = os.getenv('BOT_EMAIL', BotConstants.DEFAULT_BOT_EMAIL)
     BOT_GITHUB = os.getenv('BOT_GITHUB', BotConstants.DEFAULT_BOT_GITHUB)
-    
+
     # Logging configuration
     LOG_LEVEL = os.getenv('LOG_LEVEL', BotConstants.DEFAULT_LOG_LEVEL)
     LOG_FORMAT = os.getenv('LOG_FORMAT', BotConstants.DEFAULT_LOG_FORMAT)
-    
+
     # Docker-specific settings
     IS_DOCKER = os.getenv('DOCKER', 'false').lower() == 'true'
-    
+
     # Database configuration (for future use)
     DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///bot.db')
     REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')
-    
+
     # Custom Jokes API configuration
     JOKES_API_URL = os.getenv('JOKES_API_URL')
     JOKES_API_KEY = os.getenv('JOKES_API_KEY')
     JOKES_API_TIMEOUT = int(os.getenv('JOKES_API_TIMEOUT', str(APIConstants.DEFAULT_TIMEOUT)))
     JOKES_API_ENDPOINT = os.getenv('JOKES_API_ENDPOINT', '/api/getJoke')
-    JOKES_API_HEADERS = APIConstants.DEFAULT_HEADERS.copy()
-    
-    # Add API key to headers if provided
-    if JOKES_API_KEY:
-        JOKES_API_HEADERS['Authorization'] = f'Bearer {JOKES_API_KEY}'
-    
+
+    # Entra ID configuration for Jokes API
+    USE_ENTRA_ID_FOR_JOKES_API = os.getenv("USE_ENTRA_ID_FOR_JOKES_API", "false").lower() in ('true', '1', 'yes')
+    ENTRA_ID_TENANT_ID = os.getenv("ENTRA_ID_TENANT_ID")
+    ENTRA_ID_CLIENT_ID = os.getenv("ENTRA_ID_CLIENT_ID")
+    ENTRA_ID_CLIENT_SECRET = os.getenv("ENTRA_ID_CLIENT_SECRET")
+    ENTRA_ID_SCOPE = os.getenv("ENTRA_ID_SCOPE")
+
+    msal_app = None
+
+    @staticmethod
+    def get_entra_id_token():
+        """
+        Retrieves a bearer token from Entra ID using MSAL with in-memory token caching.
+        """
+        if not all([Config.ENTRA_ID_TENANT_ID, Config.ENTRA_ID_CLIENT_ID, Config.ENTRA_ID_CLIENT_SECRET, Config.ENTRA_ID_SCOPE]):
+            logging.error("Entra ID configuration is incomplete.")
+            return None
+
+        if Config.msal_app is None:
+            authority = f"https://login.microsoftonline.com/{Config.ENTRA_ID_TENANT_ID}"
+            Config.msal_app = msal.ConfidentialClientApplication(
+                client_id=Config.ENTRA_ID_CLIENT_ID,
+                authority=authority,
+                client_credential=Config.ENTRA_ID_CLIENT_SECRET,
+            )
+
+        result = Config.msal_app.acquire_token_for_client(scopes=[Config.ENTRA_ID_SCOPE])
+
+        if "access_token" in result:
+            return result["access_token"]
+        else:
+            logging.error(f"Failed to get Entra ID token: {result.get('error_description')}")
+            return None
+
     # Admin configuration
     ADMIN_USER_IDS = []
     _admin_ids_str = os.getenv('ADMIN_USER_IDS', '')
@@ -55,10 +86,10 @@ class Config(BaseConfig):
             ADMIN_USER_IDS = [int(uid.strip()) for uid in _admin_ids_str.split(',') if uid.strip()]
         except ValueError:
             pass
-    
+
     # Statistics configuration
     STATS_DATA_DIR = os.getenv('STATS_DATA_DIR', BotConstants.DEFAULT_STATS_DATA_DIR)
-    
+
     # Full API URL with endpoint
     @classmethod
     def get_jokes_api_url(cls):
@@ -66,7 +97,7 @@ class Config(BaseConfig):
         if not cls.JOKES_API_URL:
             return None
         return f"{cls.JOKES_API_URL.rstrip('/')}{cls.JOKES_API_ENDPOINT}"
-    
+
     @classmethod
     def validate(cls) -> bool:
         """Validate required configuration"""
@@ -79,12 +110,12 @@ class Config(BaseConfig):
                 "JOKES_API_URL is required for joke functionality. Set it as environment variable."
             )
         return True
-    
+
     @classmethod
     def get_required_vars(cls) -> List[str]:
         """Get list of required environment variables"""
         return ['BOT_TOKEN', 'JOKES_API_URL']
-    
+
     @classmethod
     def get_optional_vars(cls) -> Dict[str, Any]:
         """Get dictionary of optional environment variables with defaults"""
@@ -99,7 +130,7 @@ class Config(BaseConfig):
             'JOKES_API_TIMEOUT': APIConstants.DEFAULT_TIMEOUT,
             'STATS_DATA_DIR': BotConstants.DEFAULT_STATS_DATA_DIR
         }
-    
+
     @classmethod
     def get_bot_info(cls):
         """Get bot information for logging"""
@@ -109,6 +140,18 @@ class Config(BaseConfig):
             'developer': cls.BOT_DEVELOPER,
             'docker': cls.IS_DOCKER
         }
+
+    @classmethod
+    def get_jokes_api_headers(cls):
+        """Get headers for Jokes API, including dynamic token"""
+        headers = APIConstants.DEFAULT_HEADERS.copy()
+        if cls.USE_ENTRA_ID_FOR_JOKES_API:
+            token = cls.get_entra_id_token()
+            if token:
+                headers['Authorization'] = f'Bearer {token}'
+        elif cls.JOKES_API_KEY:
+            headers['Authorization'] = f'Bearer {cls.JOKES_API_KEY}'
+        return headers
 
 # Validate configuration on import
 Config.validate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ python-telegram-bot>=21.0.0
 python-dotenv==1.0.0
 requests==2.31.0
 polib==1.1.1
+msal==1.24.1
 
 # Optional dependencies for future features
 # sqlalchemy==2.0.23

--- a/utils.py
+++ b/utils.py
@@ -104,7 +104,8 @@ async def fetch_joke(user_input: str, lang: str) -> Optional[Dict[str, Any]]:
 
         logger.info(f"Making request to: {api_url}")
         logger.info(f"Request data: {request_data}")
-        logger.info(f"Headers: {Config.JOKES_API_HEADERS}")
+        headers = Config.get_jokes_api_headers()
+        logger.debug(f"Headers: {headers}")
 
         # Use asyncio to run the blocking request in a thread pool
         loop = asyncio.get_event_loop()
@@ -114,7 +115,7 @@ async def fetch_joke(user_input: str, lang: str) -> Optional[Dict[str, Any]]:
                 api_url,
                 json=request_data,
                 timeout=Config.JOKES_API_TIMEOUT,
-                headers=Config.JOKES_API_HEADERS
+                headers=headers
             )
         )
 


### PR DESCRIPTION
This pull request introduces support for authenticating with the Jokes API using Entra ID (Microsoft identity platform), in addition to the existing API key method. It updates the configuration, documentation, and runtime logic to dynamically select the appropriate authentication method and retrieve tokens as needed.

Key changes:

**Entra ID Authentication Support:**

* Added new configuration options in `config.py` for Entra ID authentication, including tenant ID, client ID, client secret, and scope. A static method `get_entra_id_token()` was introduced to fetch bearer tokens using MSAL if Entra ID authentication is enabled.
* The method `get_jokes_api_headers()` now dynamically selects between Entra ID and API key authentication, returning the appropriate headers for the Jokes API request.

**Runtime Logic Updates:**

* Updated `fetch_joke` in `utils.py` to use `get_jokes_api_headers()` for setting request headers, ensuring the correct authentication method is used at runtime. [[1]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL107-R108) [[2]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL117-R118)

**Documentation Improvements:**

* Expanded the `README.md` to document both API key and Entra ID authentication options for the Jokes API, including all relevant environment variables.

**Dependency Update:**

* Added the `msal` library import in `config.py` to support Entra ID authentication.